### PR TITLE
PR for #3: image-grid elements are missized for images without overlays

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -113,9 +113,6 @@ img {
     overflow: hidden;
 }
 
-.image-cover p {
-    margin: 0;
-}
 
 .image-cover img {
     width: 100%;

--- a/scripts/images.lua
+++ b/scripts/images.lua
@@ -79,9 +79,7 @@ end
 
 function create_image_item(image_data, base_path)
     -- Create HTML structure for a single image item
-    local image_elem = pandoc.Para({
-        pandoc.Image("", base_path .. image_data.image, "")
-    })
+    local image_elem = pandoc.Image("", base_path .. image_data.image, "")
 
     if image_data.description then
         -- Interactive overlay structure for hoverable images with description


### PR DESCRIPTION
This pull request solves issue #3 where image-grid elements extended 16 pixels below an image that had no overlay enabled.

It solves this issue by removing the `<p>` elements that wrapped all images in the lua script.

After solution:

<img width="775" height="420" alt="Screenshot 2025-08-24 at 11 56 10 AM" src="https://github.com/user-attachments/assets/40ea01df-c4dd-4382-86a4-3f90d1b18e26" />
